### PR TITLE
Fix for bug that triggers a HTTP GET to null

### DIFF
--- a/source/js/ng-img-crop.js
+++ b/source/js/ng-img-crop.js
@@ -62,12 +62,14 @@ crop.directive('imgCrop', ['$timeout', 'cropHost', 'cropPubSub', function($timeo
                             scope.urlBlob = urlCreator.createObjectURL(blob);
                         });
 
-                        cropHost.getDominantColor(scope.resultImage).then(function(dominantColor) {
-                            scope.dominantColor = dominantColor;
-                        });
-                        cropHost.getPalette(scope.resultImage).then(function(palette) {
-                            scope.paletteColor = palette;
-                        });
+                        if (scope.resultImage) {
+                            cropHost.getDominantColor(scope.resultImage).then(function(dominantColor) {
+                                scope.dominantColor = dominantColor;
+                            });
+                            cropHost.getPalette(scope.resultImage).then(function(palette) {
+                                scope.paletteColor = palette;
+                            });
+                        }
 
                         updateAreaCoords(scope);
                         scope.onChange({


### PR DESCRIPTION
During initialization, when scope.resultImage isn't set yet, there is a HTTP GET to http://hostname/app/null. Not sure what's causing this exactly, but the following check should prevent it from happening:
                        if (scope.resultImage) {
                            cropHost.getDominantColor(scope.resultImage).then(function(dominantColor) {
                                scope.dominantColor = dominantColor;
                            });
                            cropHost.getPalette(scope.resultImage).then(function(palette) {
                                scope.paletteColor = palette;
                            });
                        }
